### PR TITLE
Add static to inline functions

### DIFF
--- a/libdieharder/dab_filltree.c
+++ b/libdieharder/dab_filltree.c
@@ -34,7 +34,7 @@ static double targetData[] = {
 0.0, 0.0, 0.0, 0.0, 0.13333333, 0.20000000, 0.20634921, 0.17857143, 0.13007085, 0.08183633, 0.04338395, 0.01851828, 0.00617270, 0.00151193, 0.00023520, 0.00001680, 0.00000000, 0.00000000, 0.00000000, 0.00000000
 };
 
-inline int insert(double x, double *array, unsigned int startVal);
+static inline int insert(double x, double *array, unsigned int startVal);
 
 int dab_filltree(Test **test,int irun) {
  int size = (ntuple == 0) ? 32 : ntuple;
@@ -105,7 +105,7 @@ int dab_filltree(Test **test,int irun) {
 }
 
 
-inline int insert(double x, double *array, unsigned int startVal) {
+static inline int insert(double x, double *array, unsigned int startVal) {
  uint d = (startVal + 1) / 2;
  uint i = startVal;
  while (d > 0) {

--- a/libdieharder/dab_filltree2.c
+++ b/libdieharder/dab_filltree2.c
@@ -92,7 +92,7 @@ static double targetData[128] = {  // size=128, generated from 6e9 samples
 0.00000000000e+00,0.00000000000e+00,0.00000000000e+00,0.00000000000e+00,
 };
 
-inline int insertBit(uint x, uchar *array, uint *i, uint *d);
+static inline int insertBit(uint x, uchar *array, uint *i, uint *d);
 
 int dab_filltree2(Test **test, int irun) {
  int size = (ntuple == 0) ? 128 : ntuple;
@@ -181,7 +181,7 @@ int dab_filltree2(Test **test, int irun) {
  * The function returns >= 0 if the path went too deep; the
  * returned value is the last position of the path.
  */
-inline int insertBit(uint x, uchar *array, uint *i, uint *d) {
+static inline int insertBit(uint x, uchar *array, uint *i, uint *d) {
  if (x != 0) {
    *i += *d;
  } else {


### PR DESCRIPTION
This is needed to avoid a link error where the inline functions appear
missing at link time.
From c99 standard inline function should either be declared static or
have an extern instance in a c file for linking.
This fix is necessary to build with gcc 7; for some reason it was not
trigerred before.

Signed-off-by: Julien Viard de Galbert <julien@vdg.name>
[Retrieved from:
https://git.buildroot.net/buildroot/tree/package/dieharder/0004-Add-static-to-inline-functions.patch]
Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>