### PR TITLE
Do not use includedir as include search path for build

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -96,9 +96,9 @@ AC_TYPE_SIZE_T
 AC_C_VOLATILE
 AC_C_INLINE
 
-DIEHARDER_CFLAGS="-I$includedir"
-dieharder_CFLAGS="-std=c99 -Wall -pedantic -I$includedir"
-libdieharder_lo_CFLAGS="-Wall -pedantic -I$includedir"
+DIEHARDER_CFLAGS=""
+dieharder_CFLAGS="-std=c99 -Wall -pedantic"
+libdieharder_lo_CFLAGS="-Wall -pedantic"
 DIEHARDER_LIBS="-L$libdir -ldieharder"
 ACLOCAL_AMFLAGS="-I m4"
 

--- a/dieharder/Makefile.am
+++ b/dieharder/Makefile.am
@@ -65,7 +65,7 @@ DEFINES = -DVERSION=$(VERSION)
 # CC = gcc
 
 # Compile flags (use fairly standard -O3 as default)
-AM_CPPFLAGS = -I ${top_srcdir}/include $(DEFINES) -I ${includedir}
+AM_CPPFLAGS = -I ${top_srcdir}/include $(DEFINES)
 AM_CFLAGS = -O3
 
 # Load flags (optional)

--- a/libdieharder/Makefile.am
+++ b/libdieharder/Makefile.am
@@ -114,7 +114,7 @@ DEFINES = -DVERSION=$(VERSION) -DLITTLE_ENDIAN=$(LITTLE_ENDIAN)
 # CC = gcc
 
 # Compile flags (use fairly standard -O3 as default)
-AM_CPPFLAGS = $(DEFINES) -I ${top_srcdir}/include -I ${includedir}
+AM_CPPFLAGS = $(DEFINES) -I ${top_srcdir}/include
 AM_CFLAGS = -O3 -Wall -pedantic -Wno-unused-variable 
 
 #========================================================================


### PR DESCRIPTION
`--includedir `is not used to specify where a program should look for headers of libraries, but to tell where it should install its own headers.

Signed-off-by: Julien Viard de Galbert <julien@vdg.name>
[Retrieved from:
https://git.buildroot.net/buildroot/tree/package/dieharder/0001-Do-not-use-includedir-as-include-search-path-for-bui.patch]
Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>