### PR TITLE
Fix missing type intptr_t

### DIFF
--- a/include/dieharder/libdieharder.h
+++ b/include/dieharder/libdieharder.h
@@ -18,6 +18,7 @@
 
 /* This turns on uint macro in c99 */
 #define __USE_MISC 1
+#include <stdint.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <unistd.h>


### PR DESCRIPTION
With glibc-2.23 `unistd.h` need `intptr_t` when `__USE_MISC` is defined.

Signed-off-by: Julien Viard de Galbert <julien@vdg.name>
[Retrieved from: https://git.buildroot.net/buildroot/tree/package/dieharder/0002-Fix-missing-type-intptr_t.patch]
Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>