### PR TITLE
Fix dieharder build.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -88,7 +88,7 @@ $(INCTIME):
 	(cd include; \
 	make)
 
-$(PROGTIME):
+$(PROGTIME): $(LIBTIME)
 	(cd $(PROGRAM); \
 	make)
 

--- a/dieharder/globals.c
+++ b/dieharder/globals.c
@@ -73,7 +73,7 @@ unsigned int sts;              /* sts test number */
 unsigned int Seed;             /* user selected seed.  Surpresses reseeding per sample.*/
 off_t tsamples;        /* Generally should be "a lot".  off_t is u_int64_t. */
 unsigned int user;             /* user defined test number */
-unsigned int verbose;          /* Default is not to be verbose. */
+extern unsigned int verbose;          /* Default is not to be verbose. */
 double Xweak;          /* "Weak" generator cut-off (one sided) */
 double Xfail;          /* "Unambiguous Fail" generator cut-off (one sided) */
 unsigned int Xtrategy;         /* Strategy used in TTD mode */


### PR DESCRIPTION
These two one-liners fixes two problems with build:
- Fix static build with configure --disable-shared (as verbose is defined twice).
- Fix parallel build of dieharder, as library need to be build before diaharder program.