### PR TITLE
Add _GNU_SOURCE for uint and M_PI with musl libc

### DIFF
--- a/include/dieharder/libdieharder.h
+++ b/include/dieharder/libdieharder.h
@@ -18,6 +18,7 @@
 
 /* This turns on uint macro in c99 */
 #define __USE_MISC 1
+#define _GNU_SOURCE 1
 #include <stdint.h>
 #include <sys/types.h>
 #include <sys/stat.h>


### PR DESCRIPTION
When building with musl libc _GNU_SOURCE need to be defined to provide uint type and M_PI macro

Signed-off-by: Julien Viard de Galbert <julien@vdg.name>
[Retrieved from: https://git.buildroot.net/buildroot/tree/package/dieharder/0003-Add-_GNU_SOURCE-for-uint-and-M_PI-with-musl-libc.patch]
Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>