### PR TITLE
Fix all-static build of dieharder tool.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -115,6 +115,7 @@ AC_SUBST(ACLOCAL_AMFLAGS)
 #   -lgsl -lgslcblas
 # for the SECOND test, required (in that order) to succeed.
 #==================================================================
+AC_CHECK_LIB([m],[log])
 AC_CHECK_HEADER([gsl/gsl_sf_gamma.h],,[AC_MSG_ERROR([Couldn't find GSL headers.  Please install the gsl-devel package.])])
 AC_CHECK_LIB([gslcblas], [main],,[AC_MSG_ERROR([Couldn't find libgsl. Please install the gsl package.])])
 AC_CHECK_LIB([gsl],[gsl_sf_gamma])

--- a/dieharder/Makefile.am
+++ b/dieharder/Makefile.am
@@ -26,7 +26,7 @@ VERSION=@VERSION@
 # SRCINCLUDES = $(shell ls *.h  2>&1 | sed -e "/\/bin\/ls:/d")
 bin_PROGRAMS = dieharder
 man1_MANS = dieharder.1
-dieharder_LDADD = ../libdieharder/libdieharder.la -lgsl -lgslcblas -lm
+dieharder_LDADD = ../libdieharder/libdieharder.la
 dieharder_SOURCES = \
 	add_ui_rngs.c \
 	add_ui_tests.c \


### PR DESCRIPTION
The all-static dieharder build should be possible by uncommenting AM_LDFLAGS = -all-static in dieharder/Makefile.am.

Unfortunately it does not work, as order of statically linked libraries is not correct.

The -lgsl -lgslcblas is already added to LIBS in configure. So the only change needed is to detect the -lm option that is missing here.

The list dieharder_LDADD is then redundant and can be removed completely.