### PR TITLE
Add full first-level p-values print option flag.

### DIFF
--- a/dieharder/output.c
+++ b/dieharder/output.c
@@ -521,6 +521,17 @@ void output_table_line(Dtest *dtest,Test **test)
      field++;
    }
 
+   if(tflag & TPSAMPLE_VALS) {
+       fprintf(stdout , "\n#=============================================================================#\n");
+       fprintf(stdout , "#                          Values of test p-values                            #\n");
+       fprintf(stdout , "#=============================================================================#\n");
+       size_t iter = 0;
+       for(iter = 0 ; iter < test[i]->psamples ; ++iter) {
+           fprintf(stdout, "%c%10.8f%c\n", table_separator, test[i]->pvalues[iter], table_separator);
+       }
+       fprintf(stdout , "#=============================================================================#\n");
+   }
+
    /*
     * No separator at the end, just EOL
     */

--- a/dieharder/output.h
+++ b/dieharder/output.h
@@ -21,10 +21,11 @@
    TSEED = 4096,
    TRATE = 8192,
    TNUM = 16384,
-   TNO_WHITE = 32768
+   TNO_WHITE = 32768,
+   TPSAMPLE_VALS = 65536
  } Table;
 
-#define TCNT 16
+#define TCNT 17
 
  /*
   * These should have a maximum length one can use in strncmp().
@@ -49,5 +50,6 @@
  "seed",
  "rate",
  "show_num",
- "no_whitespace"
+ "no_whitespace",
+ "psample_values"
  };


### PR DESCRIPTION
Tests presents only the final p-value, but for analysis it is sometimes useful also full first-level pvalues.

As these are easily available internally, just add new -D flag to print the full p-values for each test.

Patch based on older version by Lubo Obratil for RTT project.

(I am not sure if you accept such extension, but it would be definitely better to have it upstream than patch it locally for us each time :-)