### PR TITLE
Remove defunct rgb_operm

### DIFF
--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -33,7 +33,7 @@ nobase_include_HEADERS = dieharder/copyright.h \
 	dieharder/rgb_lagged_sums.h \
 	dieharder/rgb_lmn.h \
 	dieharder/rgb_minimum_distance.h \
-	dieharder/rgb_operm.h \
+	#dieharder/rgb_operm.h \
 	dieharder/rgb_persist.h \
 	dieharder/rgb_permutations.h \
 	dieharder/rgb_timing.h \

--- a/include/dieharder/tests.h
+++ b/include/dieharder/tests.h
@@ -11,7 +11,7 @@
 #include <dieharder/rgb_kstest_test.h>
 #include <dieharder/rgb_lagged_sums.h>
 #include <dieharder/rgb_minimum_distance.h>
-#include <dieharder/rgb_operm.h>
+//#include <dieharder/rgb_operm.h>
 #include <dieharder/rgb_permutations.h>
 #include <dieharder/dab_bytedistrib.h>
 #include <dieharder/dab_dct.h>
@@ -80,7 +80,7 @@
    RGB_PERMUTATIONS,
    RGB_LAGGED_SUMS,
    RGB_LMN,
-   RGB_OPERM,
+   //RGB_OPERM,
    DAB_BYTEDISTRIB,
    DAB_DCT,
    DAB_FILLTREE,


### PR DESCRIPTION
[Retrieved (and slightly updated) from:
https://github.com/eddelbuettel/dieharder/pull/2/commits/40d377b86c856f5a4510a6f5cd56be004873ad77]
Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>