### PR TITLE
Add flag to print total read rands for file input.

### DIFF
--- a/dieharder/output.c
+++ b/dieharder/output.c
@@ -81,13 +81,21 @@ void output(Dtest *dtest,Test **test)
   * rewinds, period.
   */
  if(strncmp("file_input",gsl_rng_name(rng),10) == 0){
-   /*
-    * This needs its own output flag and field.  I'm losing it for now.
-   if(!quiet){
-     fprintf(stdout,"# %u rands were used in this test\n",file_input_get_rtot(rng));
+   if(tflag & TFILE_RNG_STAT) {
+     if(strncmp("file_input_raw",gsl_rng_name(rng),14) == 0){
+       fprintf(stdout,"# The %s %s %lu rands (%llu bytes) were used\n",
+               filename, gsl_rng_name(rng),file_input_get_rtot(rng),
+               (unsigned long long)file_input_get_rtot(rng) * sizeof(uint));
+     } else {
+       fprintf(stdout,"# The file %s %s %lu rands were used\n",
+               filename, gsl_rng_name(rng),file_input_get_rtot(rng));
+     }
+     if(file_input_get_rewind_cnt(rng) == 0){
+       fprintf(stdout,"# The file %s was rewound %u times\n",
+               gsl_rng_name(rng),file_input_get_rewind_cnt(rng));
+     }
      fflush(stdout);
    }
-    */
    if(file_input_get_rewind_cnt(rng) != 0){
      fprintf(stderr,"# The file %s was rewound %u times\n",gsl_rng_name(rng),file_input_get_rewind_cnt(rng));
      fflush(stderr);

--- a/dieharder/output.h
+++ b/dieharder/output.h
@@ -22,10 +22,11 @@
    TRATE = 8192,
    TNUM = 16384,
    TNO_WHITE = 32768,
-   TPSAMPLE_VALS = 65536
+   TPSAMPLE_VALS = 65536,
+   TFILE_RNG_STAT = 131072
  } Table;
 
-#define TCNT 17
+#define TCNT 18
 
  /*
   * These should have a maximum length one can use in strncmp().
@@ -51,5 +52,6 @@
  "rate",
  "show_num",
  "no_whitespace",
- "psample_values"
+ "psample_values",
+ "file_rng_stat"
  };


### PR DESCRIPTION
Total number of random values is quite important information, specifically if input file need to be rewinded.

Add TFILE_RNG_STAT output flag to display total random numbers read (also bytes for raw file input).

Also print number of rewinds (if not already printed to stderr).

Note, rewind is done once the file size reached
(so for fully processed file, rewind count is 1).

Also, the counter can be reset after each test with -S 0 -s 1 options.

Signed-off-by: Milan Broz <gmazyland@gmail.com>