### PR TITLE
CI: disable make distcheck as it requires legacy svn commands

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -19,5 +19,5 @@ jobs:
       run: make
     - name: make check
       run: make check
-    - name: make distcheck
-      run: make distcheck
+#    - name: make distcheck
+#      run: make distcheck


### PR DESCRIPTION
I am not sure what is the release process, but make distcheck is apparently broken now.

I think configure & make tests should be ok for nowI, so I  commented out distcheck temporarily...