### PR TITLE
Fix segfault for wrongly specified test on commandline.

### DIFF
--- a/dieharder/run_test.c
+++ b/dieharder/run_test.c
@@ -28,7 +28,7 @@ void run_test()
      }
    }
  }
- if(dtest_num >= 0){
+ if(dtest_num >= 0 && dtest_num < MAXTESTS && dh_test_types[dtest_num]){
    execute_test(dtest_num);
  } else {
    fprintf(stderr,"Error:  dtest_num = %d.  No test found.\n",dtest_num);


### PR DESCRIPTION
If explicitly specified test does not exist,
dieharder segfaults, for example
  dieharder -d 42
  dieharder -d 5000