### PR TITLE
Do not report file input rewind if nothing was read repeatedly.

### DIFF
--- a/libdieharder/rng_file_input.c
+++ b/libdieharder/rng_file_input.c
@@ -49,6 +49,14 @@ static void file_input_set (void *vstate, unsigned long int s);
 uint file_input_get_rewind_cnt(gsl_rng *rng)
 {
   file_input_state_t *state = (file_input_state_t *) rng->state;
+
+  /*
+   * End of file was reached, but nothing was read yet (repeatedly).
+   * Do not report file rewind yet.
+   */
+  if (state->rewind_cnt > 0 && state->rptr == 0)
+    return state->rewind_cnt - 1;
+
   return state->rewind_cnt;
 }
 


### PR DESCRIPTION
Some tests require a fixed amount of data.
Currently, with file input, if the size is exact, the file rewind is reported, although nothing is being read repeatedly (only EOF was reached).
The file must contain more bytes than needed to avoid it.

As we use the file rewind message to detect problems with input size, this patch modifies the rewind count function not to detect rewind if nothing has been read repeatedly yet.
The function is used in output.c only, this seems the simplest solution.

Simple reproducible with the DBA OPSO2 test that requires exactly 256M:
 dd if=/dev/urandom of=test.img bs=1M count=256
 dieharder -d 211 -g 201 -f test.img
  
This message appears
   ``The file file_input_raw was rewound 1 times``

Adding 4 more bytes (that are never read), the test is happy again
truncate -s 268435460 test.img

With this patch, adding more data is no longer needed, while real rewind reads are still reported.