### PR TITLE
Avoid overflow in DAB Monobit2 test.

### DIFF
--- a/libdieharder/dab_monobit2.c
+++ b/libdieharder/dab_monobit2.c
@@ -42,6 +42,10 @@ int dab_monobit2(Test **test, int irun)
      if ( nsamp*gsl_ran_binomial_pdf(nmax/2,0.5,nmax) < 20 ) break;
    }
    ntup = j;
+ } else if (ntup >= BLOCK_MAX) {
+   fprintf(stderr,"Error:  Can only use ntup up to %i.\n", BLOCK_MAX-1);
+   fprintf(stderr,"        Read test description with dieharder -d 209 -h.\n");
+   exit(0);
  }
 
  test[0]->ntuple = ntup;


### PR DESCRIPTION
With default ntup 0, the DAB Monobit 2 test tries to select maximum block, but only up to the fixed BLOCK_MAX.

User can override the test with ntup value (-n option) but as there are fixed allocation of pvalues, only values up to BLOCK_MAX-1 (15) are allowed.
(Increasing BLOCK_MAX would cause malloc to fail anyway.)

Skipping automatic block size detection could also cause test to fail if there is not enough samples.

Fix possible overflow by exiting the program with
an error message as there is no proper invalid return code check (as seen in other tests too).

Segfault/overflow easily reproducible with
  truncate -s 256M test.img
  dieharder/dieharder -n 32 -d 209 -g 201 -f test.img