### PR TITLE
support files with 2^31 or more PRNs

### DIFF
--- a/dieharder/globals.c
+++ b/dieharder/globals.c
@@ -9,6 +9,7 @@
  * Dirk Eddelbuettel, Dec 2019, Dec 2022
  */
 
+#include <stdint.h>
 #include <sys/time.h>
 #include <sys/types.h>
 
@@ -93,7 +94,7 @@ char **fields;
 char filename[K];      /* Input file name */
 int fromfile;		/* set true if file is used for rands */
 int filenumbits;	/* number of bits per integer */
-off_t filecount;	/* number of rands in file */
+int64_t filecount;	/* number of rands in file */
 char filetype;         /* file type */
 
 const gsl_rng_type **types;       /* where all the rng types go */

--- a/include/dieharder/libdieharder.h
+++ b/include/dieharder/libdieharder.h
@@ -18,6 +18,7 @@
 #include <string.h>
 #include <sys/time.h>
 #include <stdint.h>
+#include <inttypes.h>
 
 /* This turns on uint macro in c99 */
 #define __USE_MISC 1
@@ -248,7 +249,7 @@
   * file_input_raw.
   */
  unsigned int file_input_get_rewind_cnt(gsl_rng *rng);
- off_t file_input_get_rtot(gsl_rng *rng);
+ int64_t file_input_get_rtot(gsl_rng *rng);
  void file_input_set_rtot(gsl_rng *rng,unsigned int value);
 
  extern char filename[K];      /* Input file name */
@@ -259,7 +260,7 @@
   * automagically u_int64_t if FILE_OFFSET_BITS is 64, according to
   * legend.
   */
- extern off_t filecount;	/* number of rands in file */
+ extern int64_t filecount;	/* number of rands in file */
  extern char filetype;         /* file type */
 /*
  * This struct contains the data maintained on the operation of
@@ -274,9 +275,9 @@
  */
  typedef struct {
     FILE *fp;
-    off_t flen;
-    off_t rptr;
-    off_t rtot;
+    int64_t flen;
+    int64_t rptr;
+    int64_t rtot;
     unsigned int rewind_cnt;
   } file_input_state_t;
 

--- a/libdieharder/rng_file_input.c
+++ b/libdieharder/rng_file_input.c
@@ -60,7 +60,7 @@ uint file_input_get_rewind_cnt(gsl_rng *rng)
   return state->rewind_cnt;
 }
 
-off_t
+int64_t
 file_input_get_rtot(gsl_rng *rng)
 {
   file_input_state_t *state = (file_input_state_t *) rng->state;
@@ -170,7 +170,7 @@ static unsigned long int file_input_get (void *vstate)
    state->rptr++;
    state->rtot++;
    if(verbose){
-     fprintf(stdout,"# file_input() %lu: %lu/%lu -> %u\n", state->rtot, state->rptr,state->flen,(uint)iret);
+     fprintf(stdout,"# file_input() %"PRId64": %"PRId64"/%"PRId64" -> %u\n", state->rtot, state->rptr,state->flen,(uint)iret);
    }
 
    /*
@@ -278,7 +278,7 @@ static void file_input_set (void *vstate, unsigned long int s)
      state->rewind_cnt++;
      if(verbose == D_FILE_INPUT || verbose == D_ALL){
        fprintf(stderr,"# file_input(): Rewinding %s at rtot = %u\n", filename,(uint) state->rtot);
-       fprintf(stderr,"# file_input(): Rewind count = %u, resetting rptr = %lu\n",state->rewind_cnt,state->rptr);
+       fprintf(stderr,"# file_input(): Rewind count = %u, resetting rptr = %"PRId64"\n",state->rewind_cnt,state->rptr);
      }
    } else {
      return;
@@ -325,16 +325,22 @@ static void file_input_set (void *vstate, unsigned long int s)
        }
      }
      if(strncmp(splitbuf[0],"count",5) == 0){
-       state->flen = atoi(splitbuf[1]);
+       if(sscanf(splitbuf[1], "%"SCNd64, &state->flen) != 1){
+         fprintf(stderr,"# file_input(): Error: invalid count value\n");
+         exit(0);
+       }
        filecount = state->flen;
        cnt++;
-       if(verbose){ 
+       if(verbose){
          fprintf(stdout,"# file_input(): cnt = %d\n",cnt);
-         fprintf(stdout,"# file_input(): state->flen set to %lu\n",state->flen);
+         fprintf(stdout,"# file_input(): state->flen set to %"PRId64"\n",state->flen);
        }
      }
      if(strncmp(splitbuf[0],"numbit",6) == 0){
-       filenumbits = atoi(splitbuf[1]);
+       if(sscanf(splitbuf[1], "%d", &filenumbits) != 1){
+         fprintf(stderr,"# file_input(): Error: invalid numbit value\n");
+         exit(0);
+       }
        cnt++;
        if(verbose){ 
          fprintf(stdout,"# file_input(): cnt = %d\n",cnt);


### PR DESCRIPTION
Given the typical storage capacities of recent hardware, dieharder should support reading PRNs from files with more than 2^31 numbers.