### PR TITLE
Fix off_t and size_t printf warnings on 32/64 bit systems.

### DIFF
--- a/dieharder/output.c
+++ b/dieharder/output.c
@@ -83,12 +83,12 @@ void output(Dtest *dtest,Test **test)
  if(strncmp("file_input",gsl_rng_name(rng),10) == 0){
    if(tflag & TFILE_RNG_STAT) {
      if(strncmp("file_input_raw",gsl_rng_name(rng),14) == 0){
-       fprintf(stdout,"# The %s %s %lu rands (%llu bytes) were used\n",
-               filename, gsl_rng_name(rng),file_input_get_rtot(rng),
+       fprintf(stdout,"# The %s %s %lld rands (%llu bytes) were used\n",
+               filename, gsl_rng_name(rng),(long long)file_input_get_rtot(rng),
                (unsigned long long)file_input_get_rtot(rng) * sizeof(uint));
      } else {
-       fprintf(stdout,"# The file %s %s %lu rands were used\n",
-               filename, gsl_rng_name(rng),file_input_get_rtot(rng));
+       fprintf(stdout,"# The file %s %s %lld rands were used\n",
+               filename, gsl_rng_name(rng),(long long)file_input_get_rtot(rng));
      }
      if(file_input_get_rewind_cnt(rng) == 0){
        fprintf(stdout,"# The file %s was rewound %u times\n",

--- a/dieharder/output_rnds.c
+++ b/dieharder/output_rnds.c
@@ -23,7 +23,7 @@ void output_rnds()
  FILE *fp;
 
  if(verbose) {
-   fprintf(stderr,"# output_rnds: Dumping %lu rands\n",tsamples);
+   fprintf(stderr,"# output_rnds: Dumping %lld rands\n",(long long)tsamples);
  }
 
  /*
@@ -118,7 +118,7 @@ void output_rnds()
      fprintf(fp,"#==================================================================\n");
      fprintf(fp,"# generator %s  seed = %lu\n",gsl_rng_name(rng),seed);
      fprintf(fp,"#==================================================================\n");
-     fprintf(fp,"type: d\ncount: %lu\nnumbit: 32\n",tsamples);
+     fprintf(fp,"type: d\ncount: %lld\nnumbit: 32\n",(long long)tsamples);
      for(i=0;i<tsamples;i++){
        j = gsl_rng_get(rng);
        fprintf(fp,"%10u\n",j);
@@ -128,7 +128,7 @@ void output_rnds()
      fprintf(fp,"#==================================================================\n");
      fprintf(fp,"# generator %s  seed = %lu\n",gsl_rng_name(rng),seed);
      fprintf(fp,"#==================================================================\n");
-     fprintf(fp,"type: f\ncount: %lu\nnumbit: 32\n",tsamples);
+     fprintf(fp,"type: f\ncount: %lld\nnumbit: 32\n",(long long)tsamples);
      for(i=0;i<tsamples;i++){
        d = gsl_rng_uniform(rng);
        fprintf(fp,"%0.10f\n",d);

--- a/libdieharder/bits.c
+++ b/libdieharder/bits.c
@@ -312,7 +312,7 @@ int get_int_bit(unsigned int i, unsigned int n)
   * Note
   */
  if(n < 0 || n > 8*sizeof(unsigned int)){
-   fprintf(stderr,"Error: bit offset %u exceeds length %lu of uint.\n",n,8*sizeof(unsigned int));
+   fprintf(stderr,"Error: bit offset %u exceeds length %zu of uint.\n",n,8*sizeof(unsigned int));
    exit(0);
  }
 

--- a/libdieharder/countx.c
+++ b/libdieharder/countx.c
@@ -232,7 +232,7 @@ int main_countx( int argc, char **argv)
   free(data);
 
   time(&z);
-  printf("number of seconds: %6lu\n", (size_t)(z-a));
+  printf("number of seconds: %6zu\n", (size_t)(z-a));
 
   return 0;
 

--- a/libdieharder/rgb_permutations.c
+++ b/libdieharder/rgb_permutations.c
@@ -113,7 +113,7 @@ int rgb_permutations(Test **test,int irun)
 
    MYDEBUG(D_RGB_PERMUTATIONS){
      for(i=0;i<k;i++) {
-       printf("# rgb_permutations: ps[%u] = %lu\n",i,ps[i]);
+       printf("# rgb_permutations: ps[%u] = %zu\n",i,ps[i]);
      }
    }
 

--- a/libdieharder/rng_file_input.c
+++ b/libdieharder/rng_file_input.c
@@ -170,7 +170,8 @@ static unsigned long int file_input_get (void *vstate)
    state->rptr++;
    state->rtot++;
    if(verbose){
-     fprintf(stdout,"# file_input() %lu: %lu/%lu -> %u\n", state->rtot, state->rptr,state->flen,(uint)iret);
+     fprintf(stdout,"# file_input() %lld: %lld/%lld -> %u\n",
+       (long long)state->rtot, (long long)state->rptr, (long long)state->flen, (uint)iret);
    }
 
    /*
@@ -277,8 +278,10 @@ static void file_input_set (void *vstate, unsigned long int s)
      state->rptr = 0;
      state->rewind_cnt++;
      if(verbose == D_FILE_INPUT || verbose == D_ALL){
-       fprintf(stderr,"# file_input(): Rewinding %s at rtot = %u\n", filename,(uint) state->rtot);
-       fprintf(stderr,"# file_input(): Rewind count = %u, resetting rptr = %lu\n",state->rewind_cnt,state->rptr);
+       fprintf(stderr,"# file_input(): Rewinding %s at rtot = %lld\n",
+         filename, (long long)state->rtot);
+       fprintf(stderr,"# file_input(): Rewind count = %u, resetting rptr = %lld\n",
+         state->rewind_cnt, (long long)state->rptr);
      }
    } else {
      return;
@@ -330,7 +333,7 @@ static void file_input_set (void *vstate, unsigned long int s)
        cnt++;
        if(verbose){ 
          fprintf(stdout,"# file_input(): cnt = %d\n",cnt);
-         fprintf(stdout,"# file_input(): state->flen set to %lu\n",state->flen);
+         fprintf(stdout,"# file_input(): state->flen set to %lld\n", (long long)state->flen);
        }
      }
      if(strncmp(splitbuf[0],"numbit",6) == 0){

--- a/libdieharder/rngav.c
+++ b/libdieharder/rngav.c
@@ -175,7 +175,7 @@ int main_rngav( int argc, char **argv)
 
   time(&z);
 
-  printf("number of seconds: %6lu\n", (size_t)(z-a));
+  printf("number of seconds: %6zu\n", (size_t)(z-a));
 
   return 0;
 

--- a/libdieharder/sts_monobit.c
+++ b/libdieharder/sts_monobit.c
@@ -71,7 +71,7 @@ int sts_monobit(Test **test, int irun)
   * that if -b bits is specified, size will be "more than enough".
   */
  MYDEBUG(D_STS_MONOBIT) {
-   printf("# rgb_bitdist(): Generating %lu bits in bitstring",test[0]->tsamples*sizeof(uint)*8);
+   printf("# rgb_bitdist(): Generating %zu bits in bitstring",test[0]->tsamples*sizeof(uint)*8);
  }
  ptest.x = 0;
 


### PR DESCRIPTION
Dieharder already uses _FILE_OFFSET_BITS=64, so off_t type is always 64bit signed integer.

However, on 32bit platforms is is presented as long long, while on 64bit it is just long (as long type is 64bit there).

As there is no specific format prefix for off_t, IMO, the safest is to use integer promotion - use larges type prefix %lld and cast value to (long long) in printf.

Also switch printf to signed integer, as off_t is always signed.

For size_t we have the same issue, but here we have already print prefix %zu that will handle size_ on all patforms.

This should replace some part of #25 except sscanf issues.